### PR TITLE
Bump IntelliTect Analyzer version to 0.1.4

### DIFF
--- a/SecretSanta/src/Directory.Build.targets
+++ b/SecretSanta/src/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+    <ItemGroup>
+        <PackageReference Include="IntelliTect.Analyzers" Version="0.1.4" />
+    </ItemGroup>
+</Project>

--- a/SecretSanta/src/SecretSanta.Api/SecretSanta.Api.csproj
+++ b/SecretSanta/src/SecretSanta.Api/SecretSanta.Api.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IntelliTect.Analyzers" Version="0.1.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\SecretSanta.Business\SecretSanta.Business.csproj" />
   </ItemGroup>
 

--- a/SecretSanta/src/SecretSanta.Business/SecretSanta.Business.csproj
+++ b/SecretSanta/src/SecretSanta.Business/SecretSanta.Business.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IntelliTect.Analyzers" Version="0.1.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\SecretSanta.Data\SecretSanta.Data.csproj" />
   </ItemGroup>
 

--- a/SecretSanta/src/SecretSanta.Data/SecretSanta.Data.csproj
+++ b/SecretSanta/src/SecretSanta.Data/SecretSanta.Data.csproj
@@ -4,8 +4,4 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="IntelliTect.Analyzers" Version="0.1.3" />
-  </ItemGroup>
-
 </Project>

--- a/SecretSanta/src/SecretSanta.Web/SecretSanta.Web.csproj
+++ b/SecretSanta/src/SecretSanta.Web/SecretSanta.Web.csproj
@@ -4,8 +4,4 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="IntelliTect.Analyzers" Version="0.1.3" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
- Bump IntelliTect Analyzer version to 0.1.4. and use Build targets to use in all projects